### PR TITLE
Added new conda-based install instructions for client and server.

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -14,9 +14,36 @@ Client Installation
 Downloading the **SimStack** client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For Linux and Windows systems, the latest version of the **SimStack** client is available `here <https://www.simstack.de/?page_id=216>`_.
-The client version installs itself and all dependencies during the first launch. After extracting the ``.tar.gz`` or ``.zip`` files
-from the downloaded archive, move it to your **local filesystem**, and run the proper commands according to your operating system.
+If you do not have a working conda or mamba installation, please install mambaforge for your architecture from `github.com/conda-forge/miniforge <https://github.com/conda-forge/miniforge>`_.
+
+After installing, make sure you have the **mamba** command available in your shell and call:
+
+.. code-block:: bash
+
+   # Create a new environment for simstack client:
+   mamba create --name=simstack simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   # Activate the environment
+   conda activate simstack
+   # and run simstack:
+   simstack
+
+If you want to use your installed simstack client, just open a shell and type:
+
+.. code-block:: bash
+
+   conda activate simstack
+   # and run simstack:
+   simstack
+
+Finally, if you want to update an existing simstack install:
+
+.. code-block:: bash
+
+   conda activate simstack
+   mamba update simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   # Or if you need a specific version, example 1.2.5:
+   mamba install simstack=1.2.5 -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+
 
 The client version requires passwordless via ``ssh`` access to communicate with the HPC. If you do not have passwordless via
 ``ssh`` access to the HPC resources already preconfigured, you need to generate a ``ssh`` keypair and transfer it to your
@@ -25,8 +52,8 @@ as shown below.
 
 .. warning:: Please run the below commands on the same local machine, where the **SimStack** client will be installed.
 
-Installation on Linux
-^^^^^^^^^^^^^^^^^^^^^
+Installation on Linux and OSX (Arm and x64)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you don't have the ``ssh`` keys, use the steps below to generate them.
 
@@ -69,6 +96,8 @@ If you don't have the ``ssh`` keys, use the steps below to generate them.
 Installation on Windows
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+You have two options on Windows: You can install either the native Windows version, or (in an updated WSL2 environment) the Linux version.
+WSL2 comes with all client tools required, so this is the recommended approach. If you want to use the Windows version, continue this tutorial.
 
 If you don't have the ``ssh`` keys, use the steps below to generate them.
 

--- a/docs/installation/server.rst
+++ b/docs/installation/server.rst
@@ -10,38 +10,40 @@ Server Installation
 .. role:: red
 .. role:: green
 
+This manual is verified for SimStackServer v1.3.4
 
 Installing the **SimStack** server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SimStackServer requires a Linux system and will automatically download a MiniForge installation on first execution. Installation does not require admin 
-rights on the server machine and can be on the same machine as the one running the client.
-Download the archive called ``DATE-simstack-server-environment.tar.gz`` and transfer
-them to the HPC machine.
+SimStackServer requires a Linux system. If you do not have a working conda or mamba installation, please install mambaforge for your architecture from `github.com/conda-forge/miniforge <https://github.com/conda-forge/miniforge>`_.
 
-Choose a folder and extract the file:
-  .. code-block:: bash
+After installing, make sure you have the **mamba** command available in your shell and call:
 
-     tar xpf *-simstack-server-environment.tar.gz     
-     realpath nanomatch/
+.. code-block:: bash
 
-Note down the path of the final realpath command. You will need to insert this into the client, when configuring.
-   *  If you want to use the embedded MiniForge interpreter (recommended), enter the ``Nanomatch/V6`` directory and execute the file ``postinstall.sh``.
-   *  If you want to use your own MiniForge interpreter, make sure ``conda`` and ``mamba`` are in your path and run
+   # Create a new environment for simstack client:
+   mamba create --name=simstack_server_v6 simstackserver -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   # Activate the environment to see if it exists
+   conda activate simstack_server_v6
 
-      .. code-block:: bash
+Note down the path of your mambaforge install (e.g. */home/you/mambaforge*), you will need to insert this into the client, when configuring.
 
-         cd nanomatch/V6
-         mamba env create -f simstack_server_environment.yml
 
-      This will create a new environment called simstack_server_v6 in your MiniForge install.
-      Afterwards generate a file called ``nanomatch/V6/simstack_conda_userenv.sh``
-      with the following contents:
+Example: Setting required WaNo exports
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      .. code-block:: bash
 
-         # Change the path in the next folder to your anaconda installation.
-         source /path/to/your/anaconda/etc/profile.d/conda.sh
+Many WaNos require a specific export, such as **NANOMATCH** to find their executables. To set this variable, please call the following with an activated environment:
+
+.. code-block:: bash
+
+   conda activate simstack_server_v6
+   conda env config vars set NANOMATCH=/path/to/your/nanomatch/folder
+   # To see if it worked:
+   conda deactivate
+   conda activate simstack_server_v6
+   echo $NANOMATCH
+
 
 Once this is finished, continue with the client setup. If you are testing and do not have a working queueing system installed, choose ``Internal`` as queueing system.
 If you are running on a HPC machine, install an appropriate queueing system, e.g. Slurm, and select this in the client.


### PR DESCRIPTION
With SimStackServer 1.3.4 we have completed the NANOMATCH / SimStackServer split. SimStackServer can now run completely within the conda / mamba ecosystem and does not need to know about NANOMATCH anymore.

As part of this SimStackServer has the feature to export whatever, e.g.

export KIT=/home/to/kit/software or
export NANOMATCH=/path/to/nm
or
export VIRTMAT=/path/to/virtmat

this should be done via setting the env files in the environment simstackserver runs in. All previous ways to configure this are also still working, but not supported anymore
(i.e. installing in nanomatch/V6 or via global config file). 

The reason is simple: The decoupling makes so many things so much easier.
a) only one mamba install in the future, even the one from the user is sufficient
b) mamba installs are completely separated from scientific software
c) nanomatch does not have a special place anymore. No more special exports.