### PR TITLE
Switch recommendation to micromamba from mambaforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install --upgrade  -r requirements.txt
       - name: Build Sphinx docs
         run: |
           make -C docs html

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -14,16 +14,16 @@ Client Installation
 Downloading the **SimStack** client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you do not have a working conda or mamba installation, please install mambaforge for your architecture from `github.com/conda-forge/miniforge <https://github.com/conda-forge/miniforge>`_.
+You will require a micromamba (recommended) or conda setup to use simstack. You can use your existing micromamba or conda installation. If you do not have a working micromamba for your architecture please install micromamba, e.g. via the automatic installation route `micromamba install docs <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`_.
 
-After installing, make sure you have the **mamba** command available in your shell and call:
+After installing, make sure you have the **micromamba** or **conda** command available in your shell and call:
 
 .. code-block:: bash
 
    # Create a new environment for the simstack client:
-   mamba create --name=simstack simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   micromamba create --name=simstack simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
    # Activate the environment
-   conda activate simstack
+   micromamba activate simstack
    # and run simstack:
    simstack
 
@@ -31,7 +31,7 @@ If you want to use your installed simstack client, just open a shell and type:
 
 .. code-block:: bash
 
-   conda activate simstack
+   micromamba activate simstack
    # and run simstack:
    simstack
 
@@ -39,10 +39,10 @@ Finally, if you want to update an existing simstack install:
 
 .. code-block:: bash
 
-   conda activate simstack
-   mamba update simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   micromamba activate simstack
+   micromamba update simstack -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
    # Or if you need a specific version, example 1.2.5:
-   mamba install simstack=1.2.5 -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   micromamba install simstack=1.2.5 -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
 
 
 The client version requires passwordless via ``ssh`` access to communicate with the HPC. If you do not have passwordless via

--- a/docs/installation/server.rst
+++ b/docs/installation/server.rst
@@ -10,39 +10,39 @@ Server Installation
 .. role:: red
 .. role:: green
 
-This manual is verified for SimStackServer v1.3.4
+This manual is verified for SimStackServer v1.3.9
 
 Installing the **SimStack** server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SimStackServer requires a Linux system. If you do not have a working conda or mamba installation, please install mambaforge for your architecture from `github.com/conda-forge/miniforge <https://github.com/conda-forge/miniforge>`_.
+SimStackServer requires a Linux system with a micromamba or conda install. You can use your existing micromamba or conda installation to install SimStackServer. If you do not have a working micromamba for your architecture please install micromamba, e.g. via the automatic installation route `micromamba install docs <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`_. Note down the path of your `MAMBA_ROOT_PREFIX`, which is set during install. You will need to insert this into the client, when configuring.
 
-After installing, make sure you have the **mamba** command available in your shell and call:
+After installing, make sure you have the **micromamba** command available in your shell and call:
 
 .. code-block:: bash
 
    # Create a new environment for simstack client:
-   mamba create --name=simstack_server_v6 simstackserver -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
+   micromamba create --name=simstack_server_v6 simstackserver -c https://mamba.nanomatch-distribution.de/mamba-repo -c conda-forge
    # Activate the environment to see if it exists
-   conda activate simstack_server_v6
+   micromamba activate simstack_server_v6
 
-Note down the path of your mambaforge install (e.g. */home/you/mambaforge*), you will need to insert this into the client, when configuring.
+If you want to use a full conda install (not recommended, but supported) instead, make sure your conda is updated and substitute conda with micromamba. The path you have to input in your client is the path of your conda install then.
 
 
 Example: Setting required WaNo exports
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-Many WaNos require a specific export, such as **NANOMATCH** to find their executables. To set this variable, please call the following with an activated environment:
+Note: The next section does not apply for the newest WaNos by Nanomatch.
+Some WaNos require a specific export, such as **NANOMATCH** or **KIT** to find their executables. To set this variable, please call the following with an activated environment:
 
 .. code-block:: bash
 
-   conda activate simstack_server_v6
-   conda env config vars set NANOMATCH=/path/to/your/nanomatch/folder
+   micromamba activate simstack_server_v6
+   micromamba env config vars set NANOMATCH=/path/to/your/nanomatch/folder
    # To see if it worked:
-   conda deactivate
-   conda activate simstack_server_v6
-   echo $NANOMATCH
+   micromamba deactivate
+   micromamba activate simstack_server_v6
+   micromamba $NANOMATCH
 
 
 Once this is finished, continue with the client setup. If you are testing and do not have a working queueing system installed, choose ``Internal`` as queueing system.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
-sphinx_rtd_theme --upgrade
+sphinx_rtd_theme
 sphinx_copybutton


### PR DESCRIPTION
mambaforge is no more. In the future all the important parts of mamba went into the conda and the mamba team will deprecate mamba. We took this as an opportunity to make simstack and simstackserver compatible with micromamba, which is much smaller and much simpler. We therefore recommend it as part of the install docs.